### PR TITLE
Drop semigroups dependency

### DIFF
--- a/nonempty-vector.cabal
+++ b/nonempty-vector.cabal
@@ -40,7 +40,6 @@ library
   build-depends:       base        >=4.9  && <5
                      , deepseq
                      , primitive   >=0.6  && <0.8
-                     , semigroups  >=0.17 && <0.20
                      , vector      >=0.12 && <0.13
 
   hs-source-dirs:      src


### PR DESCRIPTION
Data.Semigroup is in base since >=4.9 (GHC-8.0).

---

I don't know how graphs are generated, so didn't regenerate them.