### PR TITLE
nonempty-vector.cabal: relax vector upper bound

### DIFF
--- a/nonempty-vector.cabal
+++ b/nonempty-vector.cabal
@@ -45,7 +45,7 @@ library
       base       >=4.9  && <5
     , deepseq
     , primitive  >=0.6  && <0.8
-    , vector     >=0.12 && <0.13
+    , vector     >=0.12 && <0.14
 
   hs-source-dirs:   src
   default-language: Haskell2010


### PR DESCRIPTION
Passes `cabal test --constraint 'vector ^>=0.13'`.