### PR TITLE
build with primitive 0.8

### DIFF
--- a/nonempty-vector.cabal
+++ b/nonempty-vector.cabal
@@ -44,7 +44,7 @@ library
   build-depends:
       base       >=4.9  && <5
     , deepseq
-    , primitive  >=0.6  && <0.8
+    , primitive  >=0.6  && <0.9
     , vector     >=0.12 && <0.14
 
   hs-source-dirs:   src


### PR DESCRIPTION
```
❯ cabal build
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - cabal-doctest-1.0.9 (lib) (requires build)
 - nonempty-vector-0.2.1.0 (lib:nonempty-vector) (first run)
Starting     cabal-doctest-1.0.9 (lib)
Building     cabal-doctest-1.0.9 (lib)
Installing   cabal-doctest-1.0.9 (lib)
Completed    cabal-doctest-1.0.9 (lib)
[1 of 2] Compiling Main             ( /home/chessai/haskell/nonempty-vector/dist-newstyle/build/x86_64-linux/ghc-9.4.4/nonempty-vector-0.2.1.0/setup/setup.hs, /home/chessai/haskell/nonempty-vector/dist-newstyle/build/x86_64-linux/ghc-9.4.4/nonempty-vector-0.2.1.0/setup/Main.o )
[2 of 2] Linking /home/chessai/haskell/nonempty-vector/dist-newstyle/build/x86_64-linux/ghc-9.4.4/nonempty-vector-0.2.1.0/setup/setup
Configuring nonempty-vector-0.2.1.0...
Preprocessing library for nonempty-vector-0.2.1.0..
Building library for nonempty-vector-0.2.1.0..
[1 of 3] Compiling Data.Vector.NonEmpty.Internal ( src/Data/Vector/NonEmpty/Internal.hs, /home/chessai/haskell/nonempty-vector/dist-newstyle/build/x86_64-linux/ghc-9.4.4/nonempty-vector-0.2.1.0/build/Data/Vector/NonEmpty/Internal.o, /home/chessai/haskell/nonempty-vector/dist-newstyle/build/x86_64-linux/ghc-9.4.4/nonempty-vector-0.2.1.0/build/Data/Vector/NonEmpty/Internal.dyn_o )
[2 of 3] Compiling Data.Vector.NonEmpty ( src/Data/Vector/NonEmpty.hs, /home/chessai/haskell/nonempty-vector/dist-newstyle/build/x86_64-linux/ghc-9.4.4/nonempty-vector-0.2.1.0/build/Data/Vector/NonEmpty.o, /home/chessai/haskell/nonempty-vector/dist-newstyle/build/x86_64-linux/ghc-9.4.4/nonempty-vector-0.2.1.0/build/Data/Vector/NonEmpty.dyn_o )
[3 of 3] Compiling Data.Vector.NonEmpty.Mutable ( src/Data/Vector/NonEmpty/Mutable.hs, /home/chessai/haskell/nonempty-vector/dist-newstyle/build/x86_64-linux/ghc-9.4.4/nonempty-vector-0.2.1.0/build/Data/Vector/NonEmpty/Mutable.o, /home/chessai/haskell/nonempty-vector/dist-newstyle/build/x86_64-linux/ghc-9.4.4/nonempty-vector-0.2.1.0/build/Data/Vector/NonEmpty/Mutable.dyn_o )
```