### PR TITLE
Make it build with ghc-9.8

### DIFF
--- a/src/Data/Vector/NonEmpty.hs
+++ b/src/Data/Vector/NonEmpty.hs
@@ -192,7 +192,7 @@ import Control.Monad.ST
 
 import qualified Data.Foldable as Foldable
 import Data.Either (Either(..))
-import Data.Functor
+import Data.Functor hiding (unzip)
 import Data.Int
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty


### PR DESCRIPTION
This makes the library itself build with `ghc-9.8.0.20230822`.

The tests still do not build because the dependencies (eg `splitmix` and almost certainly others) need an update.