### PR TITLE
Add support for GHC `9.10`.

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        ghc: ['8.10', '9.0', '9.2', '9.4', '9.6', '9.8']
+        ghc: ['8.10', '9.0', '9.2', '9.4', '9.6', '9.8', '9.10']
         include:
         - os: macOS-latest
           ghc: 'latest'

--- a/nonempty-vector.cabal
+++ b/nonempty-vector.cabal
@@ -23,6 +23,7 @@ tested-with:
    || ==9.4.4
    || ==9.6.4
    || ==9.8.1
+   || ==9.10.1
 
 source-repository head
   type:     git

--- a/nonempty-vector.cabal
+++ b/nonempty-vector.cabal
@@ -35,7 +35,7 @@ library
     Data.Vector.NonEmpty.Mutable
 
   build-depends:
-      base       >=4.14  && <4.20
+      base       >=4.14  && <4.21
     , deepseq
     , primitive  >=0.6  && <0.10
     , vector     >=0.12 && <0.14
@@ -49,7 +49,7 @@ test-suite tasty
   type:              exitcode-stdio-1.0
   main-is:           Main.hs
   build-depends:
-      base     >=4.14 && <4.20
+      base     >=4.14 && <4.21
     , nonempty-vector
     , QuickCheck
     , tasty


### PR DESCRIPTION
This PR:
- bumps the upper dependency bound for `base` to `< 4.21`.
- adds GHC version `9.10.1` to the `tested-with` list.
- adds GHC version `9.10` to the CI build matrix.

I pre-tested the updates to CI here:
https://github.com/jonathanknowles/nonempty-vector/actions/runs/9106430188?pr=1